### PR TITLE
Fix handling of gzip-encoded text response

### DIFF
--- a/zappa/handler.py
+++ b/zappa/handler.py
@@ -583,7 +583,16 @@ class LambdaHandler:
                         )
 
                     if response.data:
-                        if (
+                        if settings.BINARY_SUPPORT and response.headers.get(
+                            "Content-Encoding"
+                        ):
+                            # We could have a text response that's gzip
+                            # encoded. Therefore, we base-64 encode it.
+                            zappa_returndict["body"] = base64.b64encode(
+                                response.data
+                            ).decode("utf-8")
+                            zappa_returndict["isBase64Encoded"] = True
+                        elif (
                             settings.BINARY_SUPPORT
                             and not response.mimetype.startswith("text/")
                             and response.mimetype != "application/json"


### PR DESCRIPTION
When Zappa receives a compressed text/plain response from the
application, it tries to process it as a text response. Instead, Zappa
should treat the response as if it were a binary one and base-64 encode
the response body.

See issue #2080 binary_support logic in handler.py (0.51.0) broke compressed text response
https://github.com/Miserlou/Zappa/issues/2080

<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/zappa/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with all of **Python 3.6**, **Python 3.7** and **Python 3.8** ? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
<!-- Please describe the changes included in this PR --> 

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->

