### PR TITLE
snap start support

### DIFF
--- a/tests/test_settings.yaml
+++ b/tests/test_settings.yaml
@@ -55,3 +55,4 @@ extendofail:
   environment_variables:
     EXTENDO: You bet
 
+  snap_start: None

--- a/tests/test_settings.yaml
+++ b/tests/test_settings.yaml
@@ -54,5 +54,9 @@ extendofail:
   prebuild_script: test_settings.prebuild_me
   environment_variables:
     EXTENDO: You bet
-
+snap_start_enabled:
+  extends: ttt888
+  snap_start: PublishedVersions
+snap_start_disabled:
+  extends: ttt888
   snap_start: None

--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -119,6 +119,7 @@ class ZappaCLI:
     authorizer = None
     xray_tracing = False
     aws_kms_key_arn = ""
+    snap_start = None
     context_header_mappings = None
     additional_text_mimetypes = None
     tags = []  # type: ignore[var-annotated]
@@ -1062,6 +1063,7 @@ class ZappaCLI:
             aws_environment_variables=self.aws_environment_variables,
             aws_kms_key_arn=self.aws_kms_key_arn,
             layers=self.layers,
+            snap_start=self.snap_start,
             wait=False,
         )
 
@@ -2299,6 +2301,7 @@ class ZappaCLI:
         self.authorizer = self.stage_config.get("authorizer", {})
         self.runtime = self.stage_config.get("runtime", get_runtime_from_python_version())
         self.aws_kms_key_arn = self.stage_config.get("aws_kms_key_arn", "")
+        self.snap_start = self.snap_start.get("snap_start", "None")
         self.context_header_mappings = self.stage_config.get("context_header_mappings", {})
         self.xray_tracing = self.stage_config.get("xray_tracing", False)
         self.desired_role_arn = self.stage_config.get("role_arn")

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -1085,6 +1085,7 @@ class Zappa:
         runtime="python3.8",
         aws_environment_variables=None,
         aws_kms_key_arn=None,
+        snap_start=None,
         xray_tracing=False,
         local_zip=None,
         use_alb=False,
@@ -1122,6 +1123,7 @@ class Zappa:
             Environment={"Variables": aws_environment_variables},
             KMSKeyArn=aws_kms_key_arn,
             TracingConfig={"Mode": "Active" if self.xray_tracing else "PassThrough"},
+            SnapStart={'ApplyOn': snap_start if snap_start else 'None'},
             Layers=layers,
         )
         if not docker_image_uri:
@@ -1271,6 +1273,7 @@ class Zappa:
         aws_environment_variables=None,
         aws_kms_key_arn=None,
         layers=None,
+        snap_start=None,
         wait=True,
     ):
         """
@@ -1314,6 +1317,7 @@ class Zappa:
             "Environment": {"Variables": aws_environment_variables},
             "KMSKeyArn": aws_kms_key_arn,
             "TracingConfig": {"Mode": "Active" if self.xray_tracing else "PassThrough"},
+            "SnapStart": {'ApplyOn': snap_start if snap_start else "None"}
         }
 
         if lambda_aws_config.get("PackageType", None) != "Image":


### PR DESCRIPTION
This pull request introduces support for SnapStart configuration in the Zappa project. The changes include updates to the configuration files, the ZappaCLI class, and the creation and updating of Lambda functions to handle SnapStart settings.

### SnapStart Configuration Support:

* [`tests/test_settings.yaml`](diffhunk://#diff-378ca0219ea02b995a28876b3ef98209694c8dedd8f10905450fd43f74247d77L57-R62): Added new stages for SnapStart configuration (`snap_start_enabled` and `snap_start_disabled`).
* [`tests/tests.py`](diffhunk://#diff-6337f0a34289544e437f2604c7c78f4455c4e211183b8bf450df853e0cff9efbR677-R716): Added a new test method `test_snap_start_configuration` to verify that SnapStart settings are correctly applied and passed to Lambda functions.
* [`zappa/cli.py`](diffhunk://#diff-550c3276a99c37a050752e67ae30179b174a970f666ccb95824a81d4160998b6R122): Updated the `ZappaCLI` class to include `snap_start` as a configuration option and ensured it is properly loaded and passed during updates and deployments. [[1]](diffhunk://#diff-550c3276a99c37a050752e67ae30179b174a970f666ccb95824a81d4160998b6R122) [[2]](diffhunk://#diff-550c3276a99c37a050752e67ae30179b174a970f666ccb95824a81d4160998b6R1066) [[3]](diffhunk://#diff-550c3276a99c37a050752e67ae30179b174a970f666ccb95824a81d4160998b6R2304)
* [`zappa/core.py`](diffhunk://#diff-1272d47d18b49cd4f64c4235c54cebd1d332950e6f54586de07be904310838b2R1088): Modified the `create_lambda_function` and `update_lambda_configuration` methods to include the `snap_start` parameter and ensure it is correctly passed to the AWS Lambda API. [[1]](diffhunk://#diff-1272d47d18b49cd4f64c4235c54cebd1d332950e6f54586de07be904310838b2R1088) [[2]](diffhunk://#diff-1272d47d18b49cd4f64c4235c54cebd1d332950e6f54586de07be904310838b2R1126) [[3]](diffhunk://#diff-1272d47d18b49cd4f64c4235c54cebd1d332950e6f54586de07be904310838b2R1276) [[4]](diffhunk://#diff-1272d47d18b49cd4f64c4235c54cebd1d332950e6f54586de07be904310838b2R1320)