### PR TITLE
Make create_event_permission idempotent so Lambda policies stop growing per deploy

### DIFF
--- a/zappa/core.py
+++ b/zappa/core.py
@@ -2966,7 +2966,7 @@ class Zappa:
                 user_pool,
             ),
         )
-        if result["ResponseMetadata"]["HTTPStatusCode"] != 201:
+        if result and result["ResponseMetadata"]["HTTPStatusCode"] != 201:
             logger.error("Cognito:  Failed to update lambda permission", result)
 
     def delete_stack(self, name, wait=False):
@@ -3578,19 +3578,28 @@ class Zappa:
 
         account_id: str = self.sts_client.get_caller_identity().get("Account")  # type: ignore
 
-        permission_response = self.lambda_client.add_permission(
-            FunctionName=lambda_name,
-            StatementId="zappa-" + "".join(random.choice(string.ascii_uppercase + string.digits) for _ in range(8)),
-            Action="lambda:InvokeFunction",
-            Principal=principal,
-            SourceArn=source_arn,
-            # The SourceAccount argument ensures that only the specified AWS account can invoke the lambda function.
-            # This prevents a security issue where if a lambda is triggered off of s3 bucket events and the bucket is
-            # deleted, another AWS account can create a bucket with the same name and potentially trigger the original
-            # lambda function, since bucket names are global.
-            # https://github.com/zappa/Zappa/issues/1039
-            SourceAccount=account_id,
-        )
+        # Deterministic, so repeated updates reuse the statement instead of appending a new one.
+        statement_id = "zappa-" + hashlib.sha256(f"{lambda_name}:{principal}:{source_arn}".encode()).hexdigest()[:16]
+
+        try:
+            permission_response = self.lambda_client.add_permission(
+                FunctionName=lambda_name,
+                StatementId=statement_id,
+                Action="lambda:InvokeFunction",
+                Principal=principal,
+                SourceArn=source_arn,
+                # The SourceAccount argument ensures that only the specified AWS account can invoke the lambda function.
+                # This prevents a security issue where if a lambda is triggered off of s3 bucket events and the bucket is
+                # deleted, another AWS account can create a bucket with the same name and potentially trigger the original
+                # lambda function, since bucket names are global.
+                # https://github.com/zappa/Zappa/issues/1039
+                SourceAccount=account_id,
+            )
+        except botocore.exceptions.ClientError as e:
+            if e.response["Error"]["Code"] != "ResourceConflictException":
+                raise
+            logger.debug("Permission {} already present on {}".format(statement_id, lambda_name))
+            return None
 
         if permission_response["ResponseMetadata"]["HTTPStatusCode"] != 201:
             logger.error("Problem creating permission to invoke Lambda function")


### PR DESCRIPTION
## Problem

`zappa update` on a long-lived stage eventually fails, with no config change:

```
PolicyLengthExceededException: The final policy size (20490) is bigger than the limit (20480).
```

## Cause

`create_event_permission` uses a random `StatementId`, so `add_permission` is never idempotent — every call appends another statement, even when an identical grant already exists.

The only thing that removes them is `_clear_policy()`, reachable only via `unschedule_events()`. `ZappaCLI.schedule()` reaches that path only when `events` is non-empty, but calls `create_async_sns_topic()` — and so `create_event_permission()` — unconditionally.

An affected stage needs all three:

- `"async_source": "sns"`
- no `events`
- `"keep_warm": false` — the default `true` appends a keep-warm event, which makes `events` non-empty and triggers the sweep

Such a stage grows ~365 bytes per update and reaches the 20480-byte limit after ~50 deploys. Ours hit 19857 bytes across 56 statements, 53 of them byte-identical SNS grants differing only in `Sid`.

## Fix

```python
statement_id = "zappa-" + hashlib.sha256(f"{lambda_name}:{principal}:{source_arn}".encode()).hexdigest()[:16]
```

plus treating `ResourceConflictException` as success and re-raising anything else. Re-adding a grant becomes a no-op, so the policy cannot grow on any stage — no sweeping, no extra `RemovePermission` calls. `update_cognito` is guarded, since `None` is now a routine return.
